### PR TITLE
Allow user to specify CB or TESTING

### DIFF
--- a/current-data.qmd
+++ b/current-data.qmd
@@ -1,8 +1,8 @@
 ---
 author: "COMPASS workflows team"
 params:
-  DROPBOX: "./testing/"
-  SITES: "TMP"
+  DROPBOX: "~/Dropbox"
+  SITES: "CB"
 date: now
 date-format: "YYYY-MM-DD HH:mm:ssZ"
 execute:
@@ -36,9 +36,11 @@ PLOT_FACTOR_LEVELS <- c("C", "F", "S", "UP", "TR", "WTE", "W")
 # User can specify groups of synoptic sites: CB or LE
 if(length(SITES == 1)) {
   if(SITES == "CB") {
-    SITES <- c("SWH", "GWI", "MSM", "GCW", "TMP")
+    SITES <- c("SWH", "GWI", "MSM", "GCW")
   } else if(SITES == "LE") {
     SITES <- c("PTR", "CRC", "OWC")
+  } else if(SITES == "TESTING") {
+    SITES <- c("SWH", "GWI", "MSM", "GCW", "TMP")
   }
 }
 

--- a/run-current-data.R
+++ b/run-current-data.R
@@ -9,13 +9,16 @@ if(Sys.getenv("CI") == "") {
   # Normal usage
     message("Please select any file in Dropbox top level")
     DROPBOX <- dirname(file.choose())
+    SITES <- readline("Sites to plot: ")
 } else {
   # Running on GitHub Actions
   message("Running on GitHub Actions!")
   DROPBOX <- "./testing/"
+  SITES <- "TESTING"
 }
 
-quarto_render("current-data.qmd", execute_params = list(DROPBOX = DROPBOX))
+quarto_render("current-data.qmd", 
+              execute_params = list(DROPBOX = DROPBOX, SITES = SITES))
                                                         
 message("All done")
 


### PR DESCRIPTION
First, this PR changes things so that "CB" maps to GWI, MSM, SWH, and GCW; users can also specify TMP or "TESTING," which runs CB+TMP.

Second, @wilsonsj100 , I can't replicate the problem you're seeing in #15 -- when I run the code on the current Dropbox data for TMP, things seem fine:

<img width="1161" height="609" alt="Screenshot 2025-10-02 at 05 50 28" src="https://github.com/user-attachments/assets/d6aa582d-0868-4a7a-aeec-864f9ce88e78" />

Are you at SERC this Friday? If yes maybe we could sit down and look at it in person. 